### PR TITLE
Fix footnote name

### DIFF
--- a/copy/entries/singletons-4.md
+++ b/copy/entries/singletons-4.md
@@ -975,9 +975,9 @@ sFoldr f z (x `SCons` xs) = (f @@ x) @@ sFoldr f z xs
 ```
 
 Where `(@@) :: Sing f -> Sing x -> Sing (f @@ x)` (or `applySing`) is the
-singleton/value-level counterpart of `Apply` or `(@@)`.[^slamda]
+singleton/value-level counterpart of `Apply` or `(@@)`.[^slambda]
 
-[^slamdba]: `(@@)` (and as we see shortly, the `singFun` functions) are all
+[^slambda]: `(@@)` (and as we see shortly, the `singFun` functions) are all
 implemented in terms of `SLambda`, the "singleton" for functions. Understanding
 the details of the implementation of `SLambda` aren't particularly important.
 


### PR DESCRIPTION
The footnote name `slambda` was misspelled, causing it not to be rendered properly on the blog post.